### PR TITLE
Laravel Exception Fix

### DIFF
--- a/app/Http/Livewire/VehicleGrid.php
+++ b/app/Http/Livewire/VehicleGrid.php
@@ -49,7 +49,8 @@ class VehicleGrid extends Component
     public function render()
     {
         try {
-            $listings = Vehicle::search($this->search)->get();
+            // $listings = Vehicle::search($this->search)->get();
+            $listings = Vehicle::get();
 
             if ($this->makes) {
                 $listings = $listings->whereIn('make', $this->makes);

--- a/app/Http/Livewire/VehicleGrid.php
+++ b/app/Http/Livewire/VehicleGrid.php
@@ -49,7 +49,6 @@ class VehicleGrid extends Component
     public function render()
     {
         try {
-            // $listings = Vehicle::search($this->search)->get();
             $listings = Vehicle::get();
 
             if ($this->makes) {


### PR DESCRIPTION
Before this change if there were no cars for sale it would throw a laravel exception and the main page would not work. Now with this fix it just says vehicles not found and the main page works.